### PR TITLE
fix install of magento module via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,6 @@
         }
     ],
     "require": {
-        "magento-hackathon/magento-composer-installer": "*"
-    },
-    "extra": {
-        "map": [
-            ["app/code/community/Inviqa/ComposerAutoloader", "public/app/code/community/Inviqa/ComposerAutoloader"],
-            ["app/etc/Inviqa_ComposerAutoloader.xml", "public/app/etc/Inviqa_ComposerAutoloader.xml"]
-        ]
+        "magento-hackathon/magento-composer-installer": "~3.0"
     }
 }

--- a/modman
+++ b/modman
@@ -1,2 +1,2 @@
-app/code/community/Inviqa/ComposerAutoloader/* public/app/code/community/Inviqa/ComposerAutoloader
-app/etc/Inviqa_ComposerAutoloader.xml public/app/etc/Inviqa_ComposerAutoloader.xml
+app/code/community/Inviqa/ComposerAutoloader/*    app/code/community/Inviqa/ComposerAutoloader
+app/etc/Inviqa_ComposerAutoloader.xml             app/etc/modules/


### PR DESCRIPTION
Not sure what the problem was.
I think those extra params. Either their wrong path, or they themselves. Not sure what they do; never got to researching them.

There are a couple of "Magento"-specific beauty fixes, but that's another PR.
